### PR TITLE
Add LiveKit configuration and dotenv support

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,3 @@
+LIVEKIT_URL=https://example.livekit.cloud
+LIVEKIT_API_KEY=your_api_key
+LIVEKIT_API_SECRET=your_api_secret

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 node_modules/
 dist/
+.env
 

--- a/package.json
+++ b/package.json
@@ -10,6 +10,10 @@
   "author": "",
   "license": "ISC",
   "type": "commonjs",
+  "dependencies": {
+    "dotenv": "^16.4.5",
+    "livekit-server-sdk": "^2.4.2"
+  },
   "devDependencies": {
     "eslint": "^9.32.0",
     "prettier": "^3.6.2",

--- a/src/config/livekit.ts
+++ b/src/config/livekit.ts
@@ -1,0 +1,7 @@
+import { LiveKitServerClient } from 'livekit-server-sdk';
+
+const url = process.env.LIVEKIT_URL ?? '';
+const apiKey = process.env.LIVEKIT_API_KEY ?? '';
+const apiSecret = process.env.LIVEKIT_API_SECRET ?? '';
+
+export const livekitClient = new LiveKitServerClient(url, apiKey, apiSecret);

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,11 @@
+import dotenv from 'dotenv';
+
+dotenv.config();
+
+const { livekitClient } = require('./config/livekit');
+
 export const placeholder = (): void => {
-  console.log('Hello from TypeScript');
+  console.log('LiveKit client ready?', !!livekitClient);
 };
 
 if (require.main === module) {


### PR DESCRIPTION
## Summary
- add `.env.example` with LiveKit placeholders
- configure `dotenv` on startup
- expose pre-configured `LiveKitServerClient`

## Testing
- `npm install dotenv livekit-server-sdk` *(fails: 403 Forbidden - GET https://registry.npmjs.org/dotenv)*
- `npm test` *(fails: Cannot find module 'dotenv')*

------
https://chatgpt.com/codex/tasks/task_e_6895c5b69ca48320ac6c114faf00d5e8