### PR TITLE
Add outbound call utility using Twilio

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,11 +12,13 @@
   "type": "commonjs",
   "dependencies": {
     "dotenv": "^16.4.5",
-    "livekit-server-sdk": "^2.4.2"
+    "livekit-server-sdk": "^2.4.2",
+    "twilio": "^4.0.0"
   },
   "devDependencies": {
     "eslint": "^9.32.0",
     "prettier": "^3.6.2",
+    "@types/node": "^22.0.0",
     "ts-node": "^10.9.2",
     "typescript": "^5.9.2"
   }

--- a/src/calling/outbound.ts
+++ b/src/calling/outbound.ts
@@ -1,0 +1,58 @@
+import { EventEmitter } from 'events';
+import twilio, { Twilio } from 'twilio';
+
+export type CallState = 'ringing' | 'answered' | 'ended';
+
+export interface CallEventEmitter extends EventEmitter {
+  on(event: 'ringing', listener: (callSid: string) => void): this;
+  on(event: 'answered', listener: (callSid: string) => void): this;
+  on(event: 'ended', listener: (callSid: string) => void): this;
+}
+
+/**
+ * Start an outbound call using the Twilio Voice API.
+ * Returns an EventEmitter that notifies about call state.
+ */
+export function startOutboundCall(phoneNumber: string): CallEventEmitter {
+  const accountSid = process.env.TWILIO_ACCOUNT_SID ?? '';
+  const authToken = process.env.TWILIO_AUTH_TOKEN ?? '';
+  const fromNumber = process.env.TWILIO_FROM_NUMBER ?? '';
+  const twimlUrl = process.env.TWILIO_CALL_URL ?? '';
+
+  const client: Twilio = twilio(accountSid, authToken);
+  const emitter: CallEventEmitter = new EventEmitter();
+
+  client.calls
+    .create({ to: phoneNumber, from: fromNumber, url: twimlUrl })
+    .then(call => {
+      emitter.emit('ringing', call.sid);
+      monitorCall(client, call.sid, emitter);
+    })
+    .catch(() => emitter.emit('ended', ''));
+
+  return emitter;
+}
+
+function monitorCall(client: Twilio, sid: string, emitter: CallEventEmitter): void {
+  const timer = setInterval(async () => {
+    try {
+      const call = await client.calls(sid).fetch();
+      switch (call.status) {
+        case 'in-progress':
+          emitter.emit('answered', call.sid);
+          break;
+        case 'completed':
+        case 'failed':
+        case 'busy':
+        case 'no-answer':
+        case 'canceled':
+          emitter.emit('ended', call.sid);
+          clearInterval(timer);
+          break;
+      }
+    } catch {
+      emitter.emit('ended', sid);
+      clearInterval(timer);
+    }
+  }, 2000);
+}

--- a/src/config/livekit.ts
+++ b/src/config/livekit.ts
@@ -1,7 +1,7 @@
-import { LiveKitServerClient } from 'livekit-server-sdk';
+import { RoomServiceClient } from 'livekit-server-sdk';
 
 const url = process.env.LIVEKIT_URL ?? '';
 const apiKey = process.env.LIVEKIT_API_KEY ?? '';
 const apiSecret = process.env.LIVEKIT_API_SECRET ?? '';
 
-export const livekitClient = new LiveKitServerClient(url, apiKey, apiSecret);
+export const livekitClient = new RoomServiceClient(url, apiKey, apiSecret);


### PR DESCRIPTION
## Summary
- add Twilio and Node type packages for PSTN support
- fix LiveKit client import to RoomServiceClient
- implement `startOutboundCall` helper that emits ringing/answered/ended events

## Testing
- `npm install twilio --registry=https://registry.npmjs.org/` *(fails: 403 Forbidden)*
- `npm install -D @types/node` *(fails: 403 Forbidden)*
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6895c908729c8320b07001eb18367e5f